### PR TITLE
Fix recentchats regex to match all chats.

### DIFF
--- a/lib/skype/wrappers/chat.rb
+++ b/lib/skype/wrappers/chat.rb
@@ -6,7 +6,7 @@ module Skype
 
   def self.chats
     search("recentchats").
-      scan(/(#[^\s,]+)[\s,]/).
+      scan(/\s(#[^\s,]+),?/).
       map{|i| Chat.new i[0] }
   end
 


### PR DESCRIPTION
The response to recentchats is a list of chats separated by commas. Since the regular expression requires a trailing space or comma, it always fails to match the last chat (or the only chat if there is only one recent chat). With this change, all chats are matched.
