### PR TITLE
Add message editing and removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ chat.messages.each do |m|
 end
 ```
 
+edit chat messages
+```ruby
+message = chat.messages.last
+
+# edit
+message.edit { |current_body| "#{current_body.upcase}!"}
+# replace
+message.body = 'New message body'
+# remove
+message.remove
+```
+
 ### Call API
 
 call

--- a/lib/skype/wrappers/chat.rb
+++ b/lib/skype/wrappers/chat.rb
@@ -59,6 +59,21 @@ module Skype
         @time
       end
 
+      def edit(body)
+        ::Skype.exec("SET CHATMESSAGE #{@id} BODY #{body}")
+        @body = body
+        @@cache.set(@id, {
+                      :user => @user,
+                      :body => @body,
+                      :time => @time
+                    }, 3600*72)
+      end
+      alias body= edit
+
+      def remove
+        edit('')
+      end
+
       def to_s
         "[#{time}] <#{user}> #{body} "
       end

--- a/lib/skype/wrappers/chat.rb
+++ b/lib/skype/wrappers/chat.rb
@@ -59,7 +59,7 @@ module Skype
         @time
       end
 
-      def edit(body)
+      def body=(body)
         ::Skype.exec("SET CHATMESSAGE #{@id} BODY #{body}")
         @body = body
         @@cache.set(@id, {
@@ -68,10 +68,13 @@ module Skype
                       :time => @time
                     }, 3600*72)
       end
-      alias body= edit
+
+      def edit
+        self.body = yield @body
+      end
 
       def remove
-        edit('')
+        self.body = ''
       end
 
       def to_s


### PR DESCRIPTION
This can be done as it is right now via

``` ruby
Skype.exec("SET CHATMESSAGE #{id} BODY #{body}")
```

However, it took me some time to find it and there is no reason why there shouldn't be a wrapper around it as it is a commonly used command.
